### PR TITLE
fixed: When both school status and real-time are selected 

### DIFF
--- a/src/@/map/ui/footer-data-source-pop-up.tsx
+++ b/src/@/map/ui/footer-data-source-pop-up.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next"
 
 const FooterContainer = styled.div`
   background: ${props => props.theme.main};
+  z-index: 2;
   @media (min-width: 768px) { /* Adjust 768px to your desktop breakpoint */
     position: sticky;
     bottom: 0;
@@ -23,7 +24,7 @@ const FooterContainer = styled.div`
 
 
 export const DataSourceHeader = styled.div`
-  margin-top: 1.5rem;
+  margin-top: 0rem;
   display: flex;
   align-items: center;
   width: calc(100% - 0.6rem);

--- a/src/@/sidebar/ui/school-view-component/common/single-school-connectivity-layer.view.tsx
+++ b/src/@/sidebar/ui/school-view-component/common/single-school-connectivity-layer.view.tsx
@@ -2,7 +2,6 @@ import { useStore } from 'effector-react';
 
 import { Div } from '~/@/common/style/styled-component-style';
 import { $stylePaintData } from '~/@/map/map.model';
-import FooterDataSourcePopUp from '~/@/map/ui/footer-data-source-pop-up';
 import { getLiveSchoolDetails } from '~/@/sidebar/school-view.utils';
 import { $isLoadingSchoolView, $schoolStats, $selectedLayerData } from '~/@/sidebar/sidebar.model';
 
@@ -38,7 +37,6 @@ const SingleSchoolConnectivityLayer = ({ schoolId }: { schoolId?: number }) => {
       <SchoolInformationWrapper>
         <SchoolInformation schoolData={schoolDetails} />
       </SchoolInformationWrapper>
-      <FooterDataSourcePopUp size={25} isFooter={false} />
     </div>
   );
 }

--- a/src/@/sidebar/ui/school-view-component/school-view-connectivity-layer/school-view-connectivity-layer.view.tsx
+++ b/src/@/sidebar/ui/school-view-component/school-view-connectivity-layer/school-view-connectivity-layer.view.tsx
@@ -7,6 +7,7 @@ import CurrentLayerNameIcon from '../../common-components/current-layer-name-Ico
 import SidebarDublicateSchoolList from '../common/dublicate-school-list-view';
 import MultiSchoolLayerView from '../common/multi-school-layer.view';
 import SingleSchoolConnnectivityLayer from '../common/single-school-connectivity-layer.view';
+import FooterDataSourcePopUp from '~/@/map/ui/footer-data-source-pop-up';
 
 export default function SchoolViewConnectivityLayer() {
   const { t } = useTranslation();
@@ -23,6 +24,7 @@ export default function SchoolViewConnectivityLayer() {
         </>
       )}
       {isMoreThenOne && <MultiSchoolLayerView schoolLength={schoolIds.length} schoolLayerList={SchoolStatsTypes} />}
+      <FooterDataSourcePopUp size={25} isFooter={false} />
     </>
   );
 };


### PR DESCRIPTION
… source is in inside each school When you select only school status -> the data source becomes one for all the schools and it´s overlayed on top of everything so it´s not readable.

<!-- 
Thanks for contributing to Giga! 
Please fill out the sections below to help us review your pull request. 
-->

### Summary
<!-- Describe the purpose of this pull request -->

### Related Issue
<!-- If this pull request relates to any issue, provide the issue number or describe the problem -->

### Proposed Changes
<!-- Describe the changes you've made -->

### Screenshots (if applicable)
<!-- Add any relevant screenshots or visuals -->

### Checklist
- [ ] I have tested these changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have reviewed my code changes.

### Additional Notes
<!-- Add any other relevant information or context -->
