### PR TITLE
fix(map): Stage- preserve layer params and prevent default filters from over…

### DIFF
--- a/src/@/map/map.init.ts
+++ b/src/@/map/map.init.ts
@@ -136,18 +136,33 @@ sample({
   target: $reloadStyle
 });
 
+const hasFilterParams = () => {
+  const params = new URLSearchParams(window.location.search);
+  return Array.from(params.keys()).some(key => key.startsWith('filter__'));
+};
+
 const $derivedCountryActiveFilterList = combine({
   countryActiveFiltersList: $countryActiveFiltersList,
   activeFiltersList: $advanceFilterList,
   schoolFocusLatLng: $schoolFocusLatLng,
 });
 
-// guard: only run when both filters loaded AND no school is focused
+// guard: apply default country filters only when:
+// - filter data is loaded
+// - no school is focused
+// - URL has no existing filter params (to avoid overriding shared URLs)
 const activeFiltersListClock = guard({
   source: $derivedCountryActiveFilterList,
   clock: merge([fetchCountryFx.doneData, fetchAdvanceFilterFx.doneData]),
-  filter: ({ countryActiveFiltersList, activeFiltersList, schoolFocusLatLng }) =>
-    countryActiveFiltersList != null && activeFiltersList != null && schoolFocusLatLng === null,
+  filter: ({ countryActiveFiltersList, activeFiltersList, schoolFocusLatLng }) => {
+    if (hasFilterParams()) return false; // 🚨 IMPORTANT FIX
+
+    return (
+      countryActiveFiltersList != null &&
+      activeFiltersList != null &&
+      schoolFocusLatLng === null
+    );
+  },
 });
 
 sample({

--- a/src/@/map/ui/advanced-filter/filter-popup-content.tsx
+++ b/src/@/map/ui/advanced-filter/filter-popup-content.tsx
@@ -74,13 +74,22 @@ const FilterPopupContent = ({ setOpen }: PropsWithChildren<{ setOpen: (open: boo
   const onApply = async (e: MouseEvent) => {
     e.preventDefault();
     const prefix = 'filter__';
-    const params = new URLSearchParams();
+    const params = new URLSearchParams(window.location.search);
+    for (const key of Array.from(params.keys())) {
+      if (key.startsWith(prefix)) {
+        params.delete(key);
+      }
+    }
+
     for (const [key, value] of Object.entries(selectedFields)) {
       if (value) {
         if (typeof value === 'object') {
           const { none_range, value: rangeValue } = value;
           if (none_range) {
-            params.set(`${prefix}${key.replace('__range', '__none_range')}`, String(rangeValue) || "null,null");
+            params.set(
+              `${prefix}${key.replace('__range', '__none_range')}`,
+              String(rangeValue) || "null,null"
+            );
           } else if (rangeValue) {
             params.set(`${prefix}${key}`, String(rangeValue));
           }
@@ -92,6 +101,20 @@ const FilterPopupContent = ({ setOpen }: PropsWithChildren<{ setOpen: (open: boo
     router.navigate(`${window.location.pathname}?${params.toString()}`);
     setOpen(false);
   }
+
+  const onReset = async (e: MouseEvent) => {
+    e.preventDefault();
+    const params = new URLSearchParams(window.location.search);
+    for (const key of Array.from(params.keys())) {
+      if (key.startsWith('filter__')) {
+        params.delete(key);
+      }
+    }
+
+    router.navigate(`${window.location.pathname}?${params.toString()}`);
+    setOpen(false)
+  }
+
   // const items = ['All data layers']
   if (!isReady) return null;
   return (
@@ -128,9 +151,8 @@ const FilterPopupContent = ({ setOpen }: PropsWithChildren<{ setOpen: (open: boo
           <Button
             type="reset"
             kind="secondary"
-            onClick={() => {
-              router.navigate(`${window.location.pathname}`);
-              setOpen(false)
+            onClick={(event: MouseEvent<Element, globalThis.MouseEvent>) => {
+              void onReset(event);
             }}>
             {t('reset')}
           </Button>


### PR DESCRIPTION
…riding URL filters

<!-- 
Thanks for contributing to Giga! 
Please fill out the sections below to help us review your pull request. 
-->

### Summary
1. Preserve existing query params while applying filters

Updated filter apply logic to:

Initialize from window.location.search

Remove only filter__* params

Merge new filters without affecting other params (e.g., layer_id, country)

2. Prevent default filters from overriding URL filters

Added guard to check if URL already contains filter params

Default filters are now applied only when no filters exist in URL

### Related Issue
<!-- If this pull request relates to any issue, provide the issue number or describe the problem -->

### Proposed Changes
<!-- Describe the changes you've made -->

### Screenshots (if applicable)
<!-- Add any relevant screenshots or visuals -->

### Checklist
- [ ] I have tested these changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have reviewed my code changes.

### Additional Notes
<!-- Add any other relevant information or context -->
