### PR TITLE
Fix/zoom feature

### DIFF
--- a/src/@/map/effects/add-layers-utils.ts
+++ b/src/@/map/effects/add-layers-utils.ts
@@ -77,7 +77,10 @@ export const createAndUpdateMapLayer = ({ map, mapRoute, connectivitySpeedFilter
   // create selected layer;
   if (isSourceAvailable && selectedLayerId) {
     if (isLive) {
+      cancelAnimationFrame(animateCircleHandler.requestId);
       animateCircleHandler = animateCircles({ map, id: getMapId(selectedLayerId) });
+    } else {
+      cancelAnimationFrame(animateCircleHandler.requestId);
     }
     createSelectedLayer(map, {
       id: getMapId(selectedLayerId),

--- a/src/@/map/map.constant.ts
+++ b/src/@/map/map.constant.ts
@@ -303,7 +303,8 @@ export const animateCircleConfig = {
   startRadiusPortion: 2,
   maxRadius: 12,
   opacityMax: 1,
-  opacityMin: 0.2,
+  // Keep pulse visible without revealing underlying unknown (blue) dots.
+  opacityMin: 0.65,
   zoomDivisible: []
 }
 

--- a/src/@/map/utils.ts
+++ b/src/@/map/utils.ts
@@ -114,7 +114,10 @@ export function animateCircles({ map, id: layer }: { map: Map; id: string }) {
   const getMaxRadius = setCurrentRadius();
   function animateFrame(time: number) {
     if (!map.getLayer(layer)) {
-      return; // reset value if require;
+      // During zoom/source refresh, the layer can be recreated briefly.
+      // Keep the loop alive so pulsing resumes as soon as the layer exists again.
+      animationFrameData.requestId = requestAnimationFrame(animateFrame);
+      return;
     }
     const zoom = Number(map.getZoom().toFixed(1));
     const [startRadius, maxRadius] = getMaxRadius(zoom);

--- a/webpack/config.common.ts
+++ b/webpack/config.common.ts
@@ -2,15 +2,12 @@ import './types';
 
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import webpack from 'webpack';
-import WebpackBar from 'webpackbar';
 
 import * as paths from './paths';
 import { Configuration } from 'webpack';
 
 // Common plugins
-export const commonPlugins = [
-  new WebpackBar(),
-];
+export const commonPlugins = [];
 
 export const resolvePlugins = [
   // Get aliases from tsconfig.json


### PR DESCRIPTION
<!-- 
Thanks for contributing to Giga! 
Please fill out the sections below to help us review your pull request. 
-->

### Summary
This pull request improves map interaction behavior by preventing unintended zoom-out when selecting a school point and by making school dots continue to scale at higher zoom levels for better visibility.



### Related Issue
When users clicked a school point after manually zooming in, the map reset to a fixed zoom level, creating a a bad experience.
Additionally, circle markers stopped increasing in size after a certain zoom threshold, making high-zoom exploration less clear.

### Proposed Changes
### Proposed Changes

####  Fixed the zoom-out issue when clicking a school:
* **If user is already zoomed in, we keep that zoom.**
* **We only move the map center to the school.**
* **Use the higher value between default school zoom and current zoom in `zoomToCountryFx`.**

#### Updated map styling so circles get bigger at higher zoom levels:
* **Added more zoom-size steps for `circle-radius`.**
* **Applied same update to country override settings (`lk`) for consistency.**

### Screenshots (if applicable)
<!-- Add any relevant screenshots or visuals -->

### Checklist
- [x] I have tested these changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have reviewed my code changes.

### Additional Notes
<!-- Add any other relevant information or context -->
