### PR TITLE
Limit PostHog to staging/prod and tag events with environment

### DIFF
--- a/src/core/analytics/posthog.ts
+++ b/src/core/analytics/posthog.ts
@@ -1,10 +1,13 @@
 import posthog from 'posthog-js';
 
-import { POSTHOG_HOST, POSTHOG_KEY } from '~/env';
+import { ENV, isProduction, isStaging, POSTHOG_HOST, POSTHOG_KEY } from '~/env';
 
 import { UserInfoType } from '../auth/types/user.type';
 
-export const isPostHogEnabled = Boolean(POSTHOG_KEY);
+// Only track staging and production. Local dev is intentionally excluded to
+// keep test traffic out of the analytics data (a missing POSTHOG_KEY would
+// also disable it, but this guards even when a dev key is configured).
+export const isPostHogEnabled = Boolean(POSTHOG_KEY) && (isStaging || isProduction);
 
 // Analytics must never break the app. Every PostHog interaction is wrapped so
 // that a failure (script blocked by an ad-blocker, network error, SDK throw)
@@ -28,6 +31,10 @@ export const initPostHog = (): void => {
       capture_pageleave: true,
       persistence: 'localStorage+cookie',
     });
+
+    // Stamp every event with the environment so staging and prod stay
+    // distinguishable even within a single PostHog project.
+    posthog.register({ environment: ENV ?? 'unknown' });
   });
 };
 


### PR DESCRIPTION
## Summary
Follow-up to #235. Restricts PostHog tracking to the staging and production environments and tags every event with its environment.

- Enable PostHog only when `ENV` is `staging` or `production`, so local dev traffic stays out of the analytics data (a missing `POSTHOG_KEY` already disabled it; this also guards when a dev key is configured).
- Register `environment` as a super property so every event is attributable to its environment, keeping staging and prod separable within a single PostHog project.

## Deployment note
`POSTHOG_KEY_DEV` is no longer needed — dev is a no-op regardless. Ensure `ENV_STG` / `ENV_PROD` resolve to `staging` / `production` (they already drive `isStaging` / `isProduction`).

## Test plan
- [ ] Staging build: verify `$pageview` / identify events reach PostHog and carry `environment: staging`
- [ ] Local dev (`ENV=development`): verify no PostHog requests are made