### PR TITLE
Feature/tech 10777/health data source

### DIFF
--- a/src/@/admin/constants/country-summary.constant.ts
+++ b/src/@/admin/constants/country-summary.constant.ts
@@ -35,6 +35,7 @@ export const defaultCountryForm = {
   "flag": "",
   "description": "",
   "data_source": "",
+  "health_data_source": "",
   "last_weekly_status_id": "",
   "date_schools_mapped": '',
   "last_weekly_status": null,

--- a/src/@/admin/types/country.type.ts
+++ b/src/@/admin/types/country.type.ts
@@ -6,6 +6,7 @@ export interface CountryType {
   map_preview: string;
   description: string;
   data_source: string;
+  health_data_source: string;
   date_schools_mapped?: any;
   integration_status: number;
   date_of_join?: any;

--- a/src/@/admin/ui/country/country-crud/form-country.tsx
+++ b/src/@/admin/ui/country/country-crud/form-country.tsx
@@ -440,6 +440,7 @@ const FormCountry = ({ isEdit, countryItemId }: { isEdit: boolean, countryItemId
       formData.append('description', formElement.description?.value);
       formData.append('iso3_format', formElement.iso3_format?.value);
       formData.append('data_source', formElement.data_source?.value);
+      formData.append('health_data_source', formElement.health_data_source?.value);
       formData.append('last_weekly_status_id', formElement.last_weekly_status_id?.value)
       formData.append('country_disclaimer', formElement.country_disclaimer?.value)
       formData.append('date_of_join', formElement.date_of_join?.value?.split('/').join('-'));
@@ -659,20 +660,38 @@ const FormCountry = ({ isEdit, countryItemId }: { isEdit: boolean, countryItemId
         <RowContainer>
           <InputContainer>
             <InputLabel>
-              Data Source
+              Data source (schools)
             </InputLabel>
             <InputBoxWrapper>
               <TextInput
                 type="text"
                 labelText=""
-                id="data-souce"
+                id="data-source-schools"
                 name="data_source"
-                placeholder='Enter data source'
+                placeholder='Enter schools data source'
                 value={formDataCountry?.data_source}
                 onChange={(e) => onUdpateCountryForm([e.target.name, e.target.value])}
               />
             </InputBoxWrapper>
           </InputContainer>
+          <InputContainer>
+            <InputLabel>
+              Data source (health)
+            </InputLabel>
+            <InputBoxWrapper>
+              <TextInput
+                type="text"
+                labelText=""
+                id="data-source-health"
+                name="health_data_source"
+                placeholder='Enter health data source'
+                value={formDataCountry?.health_data_source}
+                onChange={(e) => onUdpateCountryForm([e.target.name, e.target.value])}
+              />
+            </InputBoxWrapper>
+          </InputContainer>
+        </RowContainer>
+        <RowContainer>
           <InputContainer>
             <InputLabel>
               Add a country disclaimer
@@ -681,7 +700,7 @@ const FormCountry = ({ isEdit, countryItemId }: { isEdit: boolean, countryItemId
               <TextInput
                 type="text"
                 labelText=""
-                id="data-souce"
+                id="country-disclaimer"
                 maxLength={255}
                 name="country_disclaimer"
                 placeholder='Enter country disclaimer(Max 255 characters)'

--- a/src/@/admin/ui/country/country-crud/list-country.tsx
+++ b/src/@/admin/ui/country/country-crud/list-country.tsx
@@ -35,7 +35,7 @@ const headers = [
   { key: 'flag', header: 'Flag' },
   { key: 'code', header: 'Code' },
   { key: 'name', header: 'Name' },
-  { key: 'data_source', header: 'Data Source' },
+  { key: 'data_source', header: 'Data source (schools)' },
   { key: 'date_of_join', header: 'Date of join' },
   { key: 'schools_total', header: 'Total schools' },
   { key: 'health_total', header: 'Total health' },

--- a/src/@/admin/ui/test/__snapshots__/country-crud.test.tsx.snap
+++ b/src/@/admin/ui/test/__snapshots__/country-crud.test.tsx.snap
@@ -628,7 +628,7 @@ exports[`Country Crud Tab > render MainCountryView 1`] = `
                   <div
                     class="cds--table-header-label"
                   >
-                    Data Source
+                    Data source (schools)
                   </div>
                 </th>
                 <th

--- a/src/@/country/country.model.ts
+++ b/src/@/country/country.model.ts
@@ -12,6 +12,7 @@ import { extractDataWithMapping, reconstructJson } from '~/lib/utils/json-mapper
 
 import { PointCoordinates } from "../../core/global-types";
 import { $activeEntityTypes } from '../entities/models/entity.model';
+import { EntityType } from '../entities/types/base-entity.type';
 import { defaultWorldView } from '../map/map.constant';
 import { $isAdminBoundaries, $isTilesAndLables, $map, $style, $stylePaintData, onReloadedMap } from '../map/map.model';
 import {
@@ -56,7 +57,20 @@ $countryMapping.on(fetchCountryFx.doneData, (_, payload) => {
   return Object.entries(extractDataWithMapping(payload, countryMapping)).filter(([_key, value]) => !!value);
 })
 
-export const $dataSource = $country.map((country) => country?.data_source ?? null);
+const dataSourceFieldByEntity: Record<EntityType, 'data_source' | 'health_data_source'> = {
+  [EntityType.SCHOOL]: 'data_source',
+  [EntityType.HEALTH]: 'health_data_source',
+};
+
+export const $dataSourceByEntity = $country.map(
+  (country) =>
+    Object.fromEntries(
+      Object.entries(dataSourceFieldByEntity).map(([entityType, field]) => [
+        entityType,
+        country?.[field] ?? '',
+      ]),
+    ) as Record<EntityType, string>,
+);
 export const $countryActiveFiltersList = $country.map((country) => country?.active_filters_list ?? null);
 export const $isLoadinCountry = fetchCountryFx.pending;
 export const $countryBenchmark = $country.map((country) => country?.benchmark_metadata?.live_layer ?? {});

--- a/src/@/map/ui/footer-data-source-pop-up.tsx
+++ b/src/@/map/ui/footer-data-source-pop-up.tsx
@@ -3,7 +3,7 @@ import { Info } from 'lucide-react';
 import { type PropsWithChildren, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { $dataSource } from '~/@/country/country.model';
+import { $dataSourceByEntity } from '~/@/country/country.model';
 import { type EntityType } from '~/@/entities';
 import {
   $currentLayerCountryDataSource,
@@ -76,7 +76,7 @@ const FooterDataSourcePopUp = ({
   showOldDataSource = false,
   entityType,
 }: FooterDataSourcePopUpProps) => {
-  const dataSource = useStore($dataSource);
+  const dataSourceByEntity = useStore($dataSourceByEntity);
   const { t } = useTranslation();
   const currentEntityType = entityType;
   const currentLayerTypeUtilsByEntity = useStore(
@@ -89,7 +89,7 @@ const FooterDataSourcePopUp = ({
   );
   const currentDataSource =
     (currentLayerCountryDataSource[currentEntityType] as LayerDataSource | null) ?? null;
-  const oldDataSource = dataSource ?? '';
+  const oldDataSource = dataSourceByEntity[currentEntityType] ?? '';
   const dataSourceName = useMemo(() => {
     const data: string[] = currentDataSource?.name
       ? splitOutsideParens(currentDataSource.name)
@@ -107,6 +107,8 @@ const FooterDataSourcePopUp = ({
     () => currentDataSource?.description?.split(';') ?? [],
     [currentDataSource?.description],
   );
+
+  if (showOldDataSource && !oldDataSource.trim()) return null;
 
   if (showOldDataSource) {
     if (!isFooter) {

--- a/src/@/map/ui/map-school-popup/school-popup-data-source.tsx
+++ b/src/@/map/ui/map-school-popup/school-popup-data-source.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { Chip, TooltipButton } from '~/@/common/style/styled-component-style';
-import { $dataSource } from '~/@/country/country.model';
+import { $dataSourceByEntity } from '~/@/country/country.model';
 import { $activeSchoolPopup } from '~/@/map/map.model';
 import {
   $currentLayerCountryDataSource,
@@ -83,7 +83,7 @@ const SOURCE_LINKS: Record<string, string> = {
 
 const SchoolPopupDataSource = () => {
   const { t } = useTranslation();
-  const dataSource = useStore($dataSource);
+  const dataSourceByEntity = useStore($dataSourceByEntity);
   const currentEntityType = useStore($activeSchoolPopup)?.entityType;
   const currentLayerTypeUtilsByEntity = useStore(
     $currentLayerTypeUtilsByEntity,
@@ -97,6 +97,9 @@ const SchoolPopupDataSource = () => {
   const currentDataSource = currentEntityType
     ? currentLayerCountryDataSource[currentEntityType]
     : null;
+  const dataSource = currentEntityType
+    ? dataSourceByEntity[currentEntityType]
+    : '';
 
   const { dataSourceName, dataSourceDescription } = useMemo(() => {
     const names = currentDataSource?.name

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -188,6 +188,7 @@ export type CountryBasic = {
   map_preview: string;
   description: string;
   data_source: string;
+  health_data_source: string;
   integration_status: IntegrationStatus;
   date_of_join: string;
   schools_with_data_percentage: number;
@@ -240,6 +241,7 @@ export type Country = {
   map_preview: string;
   description: string;
   data_source: string;
+  health_data_source: string;
   date_schools_mapped: string;
   statistics: CountryWeeklyStats;
   country_disclaimer: string;


### PR DESCRIPTION
Admin panel
- The country form's `Data source` field becomes `Data source (schools)`, and a new `Data source (health)` field (`health_data_source`) is added. The list column header is renamed to match.
- The country disclaimer moves to its own row, since the previous one already held two fields.

Map panel 
- `$dataSource` is no longer a scalar; it becomes `$dataSourceByEntity`, keyed by entity. This fixes an existing bug: `FooterDataSourcePopUp` renders once per active entity, so
  the health card was showing the schools data source.
- The panel is now hidden when an entity has no data source configured, instead of rendering the label with empty content.