### PR TITLE
fix: remove 'Countries with immediate access' copy on Request API Key popup (TECH-10708)

### DIFF
--- a/src/@/api-docs/ui/components/modals/request-api-key-popup.tsx
+++ b/src/@/api-docs/ui/components/modals/request-api-key-popup.tsx
@@ -1,7 +1,6 @@
 import { Button, Form, Link, TextArea } from '@carbon/react';
-import { Information } from '@carbon/icons-react';
 
-import { Div, Text } from '~/@/common/style/styled-component-style';
+import { Text } from '~/@/common/style/styled-component-style';
 import { useStore } from 'effector-react';
 import { FormEvent, useEffect } from 'react';
 
@@ -89,13 +88,6 @@ const ReuestApiKeyPopup = () => {
           {exploreApiData?.code === "DAILY_CHECK_APP" && <>
             <Text style={{ fontSize: '0.8rem' }}><b> License:</b> The dataset accessed through this API is made available under the <Link rel="noreferrer" style={{ fontSize: '0.7rem', display: 'inline' }} target="_blank" href="https://opendatacommons.org/licenses/odbl/1-0/">Open Data Commons Open Database License (ODbL)</Link>. You are free to copy, distribute, transmit and adapt our data, as long as you credit Giga and its contributors. If you alter or build upon our data, you may distribute the result only under the same licence. The full legal code explains your rights and responsibilities.
             </Text>
-            <br />
-            <Div $style={`display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.8rem;`}>
-              <Information />
-              <Text style={{ fontSize: '0.8rem', margin: 0 }}><b>Countries with immediate access</b>: Malawi<br />
-                For rest of other countries, access will be granted based on the request.
-              </Text>
-            </Div>
           </>
           }
           <ModalDescription> Please select the countries for which you need data access. Please explain how you plan to utilise the data for each country.  </ModalDescription>


### PR DESCRIPTION
## What
Removes the **"Countries with immediate access: Malawi"** info block from the Request API Key popup ([TECH-10708](https://app.clickup.com/t/86e2etadz)).

All API access is now request-based, so the immediate-access note no longer applies.

## Changes
- Deleted the info block (Information icon + Malawi copy) in `request-api-key-popup.tsx`
- Removed the now-unused `Information` and `Div` imports

## Ticket
[TECH-10708 — Fix copy on API page - Giga Maps v2.1.3.0](https://app.clickup.com/t/86e2etadz)

## Testing
- `tsc --noEmit` passes on the file
- No new lint warnings introduced
- Ran locally against dev backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
